### PR TITLE
Support for Django 4.2 and Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         db_url: [ '', 'postgresql://pg:pgpass@localhost/bdmodels' ]
 
     steps:
@@ -47,11 +47,10 @@ jobs:
     - name: Tox me
       run: |
         TOXPY="py$( echo ${{ matrix.python-version }} | sed s/\\.// )"
-        # Keeping this block for reference on how we choose Django versions based on Python
-        # if [ $TOXPY == 'py37' ]; then
-        #    TOXDJ='django{22,31,32}'
-        # else
-        #    TOXDJ='django{22,31,32,40}'
-        # fi
-        TOXDJ='django{32,40,41,main}'
-        BDMODELS_DB=${{ matrix.db_url }} tox -e $TOXPY-"$TOXDJ"
+        # Skip envs with the wrong Python using TOX_SKIP_ENV var.
+        # The below constructs, e.g. for py310, the string '(?!py310).*'
+        # (?!...) is negative lookahead; the expr matches anything which doed _not_
+        # start with 'py310'; and all the matched envs are excluded, so this ensures
+        # we only run the envs defined for the given Python.
+        export TOX_SKIP_ENV='(?!'"${TOXPY}).*"
+        BDMODELS_DB=${{ matrix.db_url }} tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Release History
 ===============
 
+0.3.1
++++++
+
+Supported versions
+------------------
+
+* Add support for upcoming Django 4.2
+
+  (required a minor, backwards-compatible change in internal API)
+
+* Add testing against Python 3.11 with supporting Django versions
+
 
 0.3.0
 +++++

--- a/bdmodels/models.py
+++ b/bdmodels/models.py
@@ -88,7 +88,12 @@ class BrokenDownQuerySet(models.QuerySet):
             return self.select_related_with_all_parents()
 
     def update_fetched_parents(self, parent_set, virtual_fields=frozenset(), *, force_update_deferrals=False):
-        """Update the set of fetched parents, and reset the set of deferred fields accordingly"""
+        """
+        Update the set of fetched parents, and reset the set of deferred fields accordingly
+
+        Virtual fields not related to parents also need special handling, or else they are forced
+        to be deferred
+        """
         if (
             (not force_update_deferrals)
             and parent_set == self._with_parents

--- a/bdmodels/models.py
+++ b/bdmodels/models.py
@@ -31,10 +31,12 @@ class BrokenDownQuerySet(models.QuerySet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._with_parents = frozenset()
+        self._with_virtuals = frozenset()
 
     def _clone(self):
         c = super()._clone()
         c._with_parents = self._with_parents
+        c._with_virtuals = self._with_virtuals
         return c
 
     @property
@@ -59,29 +61,45 @@ class BrokenDownQuerySet(models.QuerySet):
                     continue
 
                 ptr_name = link.name
-                for field in field_heads:
+                for field in field_heads.copy():
                     if field == ptr_name:
                         with_parents.add(parent)
+                        field_heads.remove(field)
                         break
                     else:
                         field_obj = self.model._meta.get_field(field)
                         if field_obj.model == parent:
                             with_parents.add(parent)
+                            field_heads.remove(field)
                             break
 
-            this = self.update_fetched_parents(with_parents)
+            # Anything left in field_heads at this point is either a virtual relation field
+            # (which still needs special treatment) or a regular field which can be handled
+            # by the normal mechanisms
+            virtuals = frozenset()
+            if field_heads:
+                related_fields = (self._concrete_model._meta.get_field(field) for field in field_heads)
+                virtuals = frozenset(
+                    field for field in related_fields if getattr(field, 'can_share_attribute', False)
+                )
+            this = self.update_fetched_parents(with_parents, virtuals)
             return super(BrokenDownQuerySet, this).select_related(*fields)
         else:
             return self.select_related_with_all_parents()
 
-    def update_fetched_parents(self, parent_set, *, force_update_deferrals=False):
+    def update_fetched_parents(self, parent_set, virtual_fields=frozenset(), *, force_update_deferrals=False):
         """Update the set of fetched parents, and reset the set of deferred fields accordingly"""
-        if (not force_update_deferrals) and parent_set == self._with_parents:
+        if (
+            (not force_update_deferrals)
+            and parent_set == self._with_parents
+            and virtual_fields == self._with_virtuals
+        ):
             return self
 
         fetched_field_names = self._get_field_names_to_fetch(parent_set)
-        updated = self.only(*fetched_field_names)
+        updated = self.only(*fetched_field_names, *(field.name for field in virtual_fields))
         updated._with_parents = frozenset(parent_set)
+        updated._with_virtuals = frozenset(virtual_fields)
         return updated
     update_fetched_parents.queryset_only = True
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -10,22 +10,27 @@ Community
 ---------
 
 The project is run and managed on `Github`_. For issues or pull requests,
-please use the tools provided there. For questions or support, please
-reach out to project contributors:
+please use the tools provided there. For questions or support, you can either
+use `Github discussions`_, or reach out to project contributors:
 
 +-------------+-----------------+---------------+-----------------------+
 | Contributor | `Django Forum`_ | Github        | Other                 |
 +=============+=================+===============+=======================+
 | Shai Berger | shaib           | shaib         | Twitter: `@shaib_il`_ |
+|             |                 |               |                       |
+|             |                 |               | Fediverse:            |
+|             |                 |               | `@shaib@tooot.im`_    |
 +-------------+-----------------+---------------+-----------------------+
 
 In all communications and actions related to this project we ask that
-you respect the code of conduct we blatantly copied from `Django`_ [*].
+you respect the code of conduct we blatantly copied from `Django`_ [*]_.
 
 .. _Matific: https://www.matific.com/
 .. _Github: https://github.com/Matific/broken-down-models
+.. _Github discussions: https://github.com/Matific/broken-down-models/discussions
 .. _`Django Forum`: https://forum.djangoproject.com
 .. _`@shaib_il`: https://twitter.com/shaib_il/
+.. _`@shaib@tooot.im`: https://tooot.im/@shaib
 .. _Django: https://www.djangoproject.com/conduct/
 
 Code of Conduct
@@ -101,10 +106,9 @@ repository. Changes to code should be accompanied by respective changes
 to tests and documentation, where relevant.
 
 The project is tested against Python>=3.8 and supported versions of
-Django (3.2.x, 4.0.x and the upcoming 4.1.x at the time this is written),
-as well as Django's main branch. We
-strongly recommend the latest stable point-release of each of the
-above.
+Django (3.2.x and 4.x.y at the time this is written), as well as
+Django's main branch. We strongly recommend the latest stable
+point-release of each of the above.
 
 We use `poetry`_ to manage builds and `tox`_ to manage tests.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,8 +15,9 @@ Requirements
 ............
 
 Broken-Down-Models is tested against CPython 3.8, 3.9 and 3.10, with
-Django 3.2, 4.0 and 4.1 (and the tip of the ``main`` branch),
-using PostgreSQL and SQLite.
+Django 3.2, 4.0, 4.1 and 4.2, using PostgreSQL and SQLite. Versions
+4.1, 4.2 and the tip of the ``main`` branch, which support Python 3.11,
+are also tested against it.
 
 When using SQLite, Some migration operations require SQLite >= 3.3.0.  See
 :py:class:`CopyDataToPartial <bdmodels.migration_ops.CopyDataToPartial>` for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dj-database-url = "^0.5.0"
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{38,39,310}-django{32,40,41,main}
+envlist = py{38,39,310}-django{32,40,41,42}, py311-django{41,42,main}
 isolated_build = True
 skipsdist = True
 
@@ -50,9 +50,10 @@ deps =
 
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
-    django41: git+https://github.com/django/django.git@stable/4.1.x#egg=django
+    django41: Django>=4.1,<4.2
+    django42: git+https://github.com/django/django.git@stable/4.2.x#egg=django
     djangomain: git+https://github.com/django/django.git@main#egg=django
-    psycopg2
+    psycopg2-binary
     dj-database-url>=0.5.0,<0.6
 
 changedir = test_bdmodels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "broken-down-models"
-version = "0.3.0"
+version = "0.3.1"
 description = "A set of utlities for breaking a large Django model down to separate components"
 readme = "README.rst"
 homepage = "https://github.com/Matific/broken-down-models"
@@ -19,6 +19,7 @@ classifiers = [
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
+    "Framework :: Django :: 4.2",
     "Intended Audience :: Developers",
     "Topic :: Database",
 ]


### PR DESCRIPTION
This is just adding the versions to the test matrix, and fixing some tests which broke.

Still needed: Some (mostly internal) API was changed, and we're not yet sure about this change; docuemnt changes, bump versions